### PR TITLE
Define _POSIX_C_SOURCE

### DIFF
--- a/tiny.c
+++ b/tiny.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include <arpa/inet.h>          /* inet_ntoa */
 #include <signal.h>
 #include <dirent.h>


### PR DESCRIPTION
On GNU libc, fdopendir is guarded by _POSIX_C_SOURCE >= 200809L.